### PR TITLE
Enhance dropdown UX: Add default 'Select a user' option to prevent au…

### DIFF
--- a/script.js
+++ b/script.js
@@ -4,23 +4,43 @@
 // Note that when running locally, in order to open a web page which uses modules, you must serve the directory over HTTP e.g. with https://www.npmjs.com/package/http-server
 // You can't open the index.html file using a file:// URL.
 
-// Import JSDOM to simulate a browser environment in Node.js
-import { JSDOM } from "jsdom";
 // Import the getUserIds function from storage.js to retrieve user IDs
 import { getUserIds } from "./storage.js";
 
 // -----------------------------------------------------------------------------------
 
-// Create a virtual DOM environment using JSDOM
-const dom = new JSDOM(`<!DOCTYPE html><body></body>`);
+document.addEventListener("DOMContentLoaded", () => {
+  const userSelect = document.getElementById("user-select");
 
-// Assign the virtual DOM objects to global variables
-// This makes Node.js behave like a browser
-global.window = dom.window; // Assigns window object
-global.document = dom.window.document; // Assigns document object
-global.navigator = dom.window.navigator; // Assigns navigator object
+  if (!userSelect) {
+    console.error("Dropdown element not found! Check index.html");
+    return;
+  }
 
-// -----------------------------------------------------------------------------------
+  const userIds = getUserIds(); // Call the function
 
-const userSelect = document.getElementById("user-select");
+  console.log("User IDs fetched:", userIds); // Debugging step
 
+  if (!userIds || userIds.length === 0) {
+    console.error("No users found! Check storage.js");
+    return;
+  }
+
+  // Create a default option
+  const defaultOption = document.createElement("option");
+  defaultOption.value = "";
+  defaultOption.textContent = "Select a user";
+  defaultOption.disabled = true;
+  defaultOption.selected = true; // Ensures it stays selected initially
+  userSelect.appendChild(defaultOption);
+
+  // Add user options
+  userIds.forEach(userId => {
+     const option = document.createElement("option");
+     option.value = userId;
+     option.textContent = `User ${userId}`;
+     userSelect.appendChild(option);
+  });
+
+  console.log("Dropdown updated with users");
+});


### PR DESCRIPTION
This PR improves the user experience of the dropdown by adding a default disabled option labeled "Select a user". This prevents the first user (User 1) from being auto-selected when the page loads.

Changes Implemented:
Added a default <option> element with disabled and selected attributes.
Ensured that users must actively select a value instead of seeing a pre-selected user.
Improved accessibility and usability by making the dropdown behavior clearer.
Logged meaningful console messages for debugging.

How to Test:
Open the project using Live Server.
Observe that the dropdown now displays "Select a user" as the default option.
Ensure users must manually choose an option.
Verify that all users (User 1 - 5) are correctly listed in the dropdown.

Why This Change?
Prevents confusion caused by automatic selection of the first user.
Enhances user control and improves form handling.

